### PR TITLE
Updated cargo references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ license = "MIT / Apache-2.0"
 description = "Low-level FBX library"
 
 [dependencies]
-log = "^0.3.5"
-byteorder = "^0.5"
-flate2 = "^0.2.13"
-rustc-serialize = "^0.3.16"
+log = "0.4.2"
+byteorder = "1.2.3"
+flate2 = "1.0.1"
+rustc-serialize = "0.3.24"
 
 [dev-dependencies]
-env_logger = "^0.3.2"
+env_logger = "0.5.10"

--- a/examples/convert-to-ascii.rs
+++ b/examples/convert-to-ascii.rs
@@ -18,9 +18,7 @@ fn indent(size: usize) -> String {
 }
 
 fn main() {
-    use std::io::Write;
-
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let filename = match std::env::args().nth(1) {
         Some(f) => f,

--- a/examples/import-export-binary.rs
+++ b/examples/import-export-binary.rs
@@ -17,9 +17,7 @@ fn indent(size: usize) -> String {
 }
 
 fn main() {
-    use std::io::Write;
-
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let filename = match std::env::args().nth(1) {
         Some(f) => f,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,7 +13,7 @@ fn indent(size: usize) -> String {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let filename = match std::env::args().nth(1) {
         Some(f) => f,

--- a/src/reader/parser/mod.rs
+++ b/src/reader/parser/mod.rs
@@ -24,7 +24,7 @@ enum ParserState {
 
 /// Common state among all sub parsers.
 #[derive(Debug, Clone)]
-struct CommonState {
+pub struct CommonState {
     /// Position of last successfully read byte.
     pos: u64,
     final_result: Option<Result<FbxEvent>>,

--- a/src/writer/emitter/binary.rs
+++ b/src/writer/emitter/binary.rs
@@ -148,7 +148,7 @@ impl BinaryEmitter {
 
                         let vec_start_pos = try!(sink.seek(SeekFrom::Current(0)));
                         {
-                            let mut encoder = flate2::write::ZlibEncoder::new(sink.by_ref(), flate2::Compression::Default);
+                            let mut encoder = flate2::write::ZlibEncoder::new(sink.by_ref(), flate2::Compression::fast());
                             for &v in $vec {
                                 //try!(encoder.write_i32::<LittleEndian>(v));
                                 try!(encoder.$elem_type_writer::<LittleEndian>(v));

--- a/tests/binary-export-import.rs
+++ b/tests/binary-export-import.rs
@@ -18,7 +18,7 @@ fn indent(size: usize) -> String {
 
 #[test]
 fn binary_export_import() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     // FBX 7.4
     binary_export_import_file("tests/assets/blender_2_72b_default-fbx7400.fbx");


### PR DESCRIPTION
I updated the cargo references.

`flate2::Compression::Default` has been removed. There seem to be several options [here](https://docs.rs/flate2/1.0.1/flate2/struct.Compression.html)
- none
- fast
- best

I picked **fast** for no apparent reason, feel free to let me know if you want me to pick another one.

https://github.com/lo48576/fbx_direct/pull/2/files#diff-3e488bfdc274744690a0f40ac31d8d67R27
`CommonState` appears in a public function ([reader/parser/ascii.rs AsciiParser::next](https://github.com/lo48576/fbx_direct/blob/master/src/reader/parser/ascii.rs#L22)) and rust complained that this would be a hard error in the future. This is why I made the struct public.

In addition, rustc_serialize has been deprecated in favor of serde: https://github.com/rust-lang-deprecated/rustc-serialize#rustc-serialize. Do you want me to update this crate to serde as well?

